### PR TITLE
Add json output similiar to what zMerge outputs

### DIFF
--- a/MutagenMerger.Lib/DI/CopyRecordProcessor.cs
+++ b/MutagenMerger.Lib/DI/CopyRecordProcessor.cs
@@ -61,11 +61,17 @@ public class CopyRecordProcessor<TMod, TModGetter>
         MajorRecord duplicated = DuplicateAndRenumber(mergeState, rec);
         // mergeState.OutgoingMod.Add(duplicated);
 
-
-        Console.WriteLine("          Renumbering Record [" + rec.Record.FormKey.ModKey.Name + "] " +
-                          rec.Record.FormKey.IDString() + " to [" + mergeState.OutgoingMod.ModKey.Name + "] " +
-                          duplicated.FormKey.IDString());
-        mergeState.Mapping.Add(rec.Record.FormKey, duplicated.FormKey);
+        if (rec.Record.FormKey.ID != duplicated.FormKey.ID)
+        {
+            Console.WriteLine("          Renumbering Record [" + rec.Record.FormKey.ModKey.Name + "] " +
+                              rec.Record.FormKey.IDString() + " to [" + mergeState.OutgoingMod.ModKey.Name + "] " +
+                              duplicated.FormKey.IDString());
+            mergeState.Mapping.Add(rec.Record.FormKey, duplicated.FormKey);
+        }
+        else {
+            Console.WriteLine("          Copying Record [" + rec.Record.FormKey.ModKey.Name + "] " +
+                              rec.Record.FormKey.IDString());
+        }
     }
 
     private static MajorRecord DuplicateAndRenumber(MergeState<TMod, TModGetter> mergeState, IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter> rec)
@@ -103,9 +109,18 @@ public class CopyRecordProcessor<TMod, TModGetter>
                 throw new NotImplementedException();
 
             var duplicate = DuplicateAndRenumber(mergeState, rec);
-            Console.WriteLine("          Renumbering Record[" + rec.Record.FormKey.ModKey.Name + "] " +
-                              rec.Record.FormKey.IDString() + " to [" + mergeState.OutgoingMod.ModKey.Name + "] " +
-                              duplicate.FormKey.IDString());
+
+            if (rec.Record.FormKey.ID != duplicate.FormKey.ID)
+            {
+                Console.WriteLine("          Renumbering Record[" + rec.Record.FormKey.ModKey.Name + "] " +
+                                  rec.Record.FormKey.IDString() + " to [" + mergeState.OutgoingMod.ModKey.Name + "] " +
+                                  duplicate.FormKey.IDString());
+            }
+            else
+            {
+                Console.WriteLine("          Copying Record[" + rec.Record.FormKey.ModKey.Name + "] " +
+                                  rec.Record.FormKey.IDString());
+            }
             mergeState.Mapping.Add(rec.Record.FormKey, duplicate.FormKey);
         }
         else

--- a/MutagenMerger.Lib/MutagenMerger.Lib.csproj
+++ b/MutagenMerger.Lib/MutagenMerger.Lib.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Mono.TextTemplating" Version="2.2.1" />
+    <PackageReference Include="System.Json" Version="4.7.1" />
     <TextTemplate Include="**\*.tt" />
     <Generated Include="**\*.Generated.cs" />
     <PackageReference Include="Mutagen.Bethesda" Version="0.41" />


### PR DESCRIPTION
- refactor shell scripts used for testing
- disable unnecessary console logs left over from previous debugging
- fix shell expansion bug with test scripts
- Add json output similiar to what zMerge outputs
